### PR TITLE
Fixed a bug in config class.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,7 +10,7 @@ class riak2::config {
   }
 
   $notify_service = $riak2::restart_on_change ? {
-    true  => [Riak2::Service[$riak2::service_name], Exec['validate_config']],
+    true  => [Service[$riak2::service_name], Exec['validate_config']],
     false => Exec['validate_config'],
   }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -28,6 +28,7 @@ describe 'riak2' do
           let(:params) {{
             :version            => '2.0.5-1',
             :disableboot        => true,
+            :restart_on_change  => true,
             :manage_service     => false,
             :platform_log_dir   => '/tmp/log_dir',
             :platform_data_dir  => '/tmp/data_dir',


### PR DESCRIPTION
When `$restart_on_change` is set to `true`. Catalog compilation will fail with: 

> Error: Failed to apply catalog: Could not find dependent Riak2::Service[riak] for File[/etc/riak/riak.conf] at /etc/puppet/modules/riak2/manifests/config.pp:27 

You want to notify the system service to restart after config change so it needs to be
 `Service[$riak2::service_name]` instead of `Riak2::Service[$riak2::service_name` 
